### PR TITLE
Drive Koopman controller to origin across systems

### DIFF
--- a/gpe_lqr_control.py
+++ b/gpe_lqr_control.py
@@ -1,0 +1,115 @@
+import numpy as np
+from typing import Callable
+from scipy.linalg import solve_discrete_are
+
+from gpe_three_systems_experiment import (
+    DuffingParams, LorenzParams, VanDerPolParams,
+    duffing_dynamics, lorenz_dynamics, vdp_dynamics,
+    rk4_step, collect_data_a_pe, collect_data_g_pe,
+    build_phi_matrix, edmdc_fit,
+    poly_features_2d, poly_features_3d
+)
+
+# -----------------------------------------------------------------------------
+# LQR helper
+# -----------------------------------------------------------------------------
+
+def dlqr(A: np.ndarray, B: np.ndarray, Q: np.ndarray, R: np.ndarray) -> np.ndarray:
+    """Discrete-time LQR via solution to the Riccati equation."""
+    P = solve_discrete_are(A, B, Q, R)
+    K = np.linalg.inv(B.T @ P @ B + R) @ (B.T @ P @ A)
+    return K
+
+
+def simulate_closed_loop(
+    dyn: Callable[[np.ndarray, float], np.ndarray],
+    feature_fn: Callable[[np.ndarray], np.ndarray],
+    A: np.ndarray,
+    B: np.ndarray,
+    K: np.ndarray,
+    x0: np.ndarray,
+    u_max: float,
+    dt: float,
+    steps: int,
+) -> tuple:
+    """Simulate Koopman-LQR closed loop."""
+    x = x0.copy()
+    xs = [x.copy()]
+    us = []
+    for _ in range(steps):
+        phi = feature_fn(x)
+        u = float(-(K @ phi))
+        u = float(np.clip(u, -u_max, u_max))
+        x = rk4_step(x, u, dt, dyn)
+        xs.append(x.copy())
+        us.append(u)
+    return np.array(xs), np.array(us)
+
+
+def build_koopman(dyn, params, feature_fn, dims, dt=0.01, L_seg=20, N_max=200, gamma=1e-2, rho0=6.0):
+    """Collect A-PE and G-PE data and fit Koopman models."""
+    # data A-PE
+    X_ape, U_ape = collect_data_a_pe(dyn, params, dt, L_seg, N_max, dims)
+    Phi_ape = build_phi_matrix(X_ape[:-1], feature_fn)
+    Phi_next_ape = build_phi_matrix(X_ape[1:], feature_fn)
+    U_row_ape = U_ape.reshape(1, -1)
+    A_phi_ape, B_phi_ape = edmdc_fit(Phi_ape, Phi_next_ape, U_row_ape)
+    # data G-PE
+    grid_sizes = (12, 24, 36) if dims == 2 else (8, 12, 16)
+    X_gpe, U_gpe, _ = collect_data_g_pe(
+        dyn=dyn, p=params, dt=dt, L_seg=L_seg, max_segments=N_max, state_dim=dims,
+        feature_fn=feature_fn, dims=dims, grid_sizes=grid_sizes,
+        gamma=gamma, rho0=rho0, cov_window=2000, ratio_window=2000)
+    Phi_gpe = build_phi_matrix(X_gpe[:-1], feature_fn)
+    Phi_next_gpe = build_phi_matrix(X_gpe[1:], feature_fn)
+    U_row_gpe = U_gpe.reshape(1, -1)
+    A_phi_gpe, B_phi_gpe = edmdc_fit(Phi_gpe, Phi_next_gpe, U_row_gpe)
+    return (A_phi_ape, B_phi_ape), (A_phi_gpe, B_phi_gpe)
+
+
+def lqr_for_system(system_name: str):
+    dt = 0.01
+    L_seg = 20
+    N_max = 200
+    gamma = 1e-2
+    rho0 = 6.0
+    if system_name == 'duffing':
+        params = DuffingParams()
+        dyn = lambda x, u: duffing_dynamics(x, u, params)
+        feature_fn = lambda x: poly_features_2d(x, degree=3)
+        dims = 2
+    elif system_name == 'lorenz':
+        params = LorenzParams()
+        dyn = lambda x, u: lorenz_dynamics(x, u, params)
+        feature_fn = lambda x: poly_features_3d(x, degree=2)
+        dims = 3
+    elif system_name == 'vdp':
+        params = VanDerPolParams()
+        dyn = lambda x, u: vdp_dynamics(x, u, params)
+        feature_fn = lambda x: poly_features_2d(x, degree=3)
+        dims = 2
+    else:
+        raise ValueError('unknown system')
+    (A_ape, B_ape), (A_gpe, B_gpe) = build_koopman(dyn, params, feature_fn, dims, dt, L_seg, N_max, gamma, rho0)
+    C = np.zeros((dims, A_ape.shape[0]))
+    C[:, :dims] = np.eye(dims)
+    Q = np.eye(dims)
+    R = np.array([[1.0]])
+    Q_lift = C.T @ Q @ C
+    K_ape = dlqr(A_ape, B_ape, Q_lift, R)
+    K_gpe = dlqr(A_gpe, B_gpe, Q_lift, R)
+    x0 = np.random.randn(dims)
+    xs_ape, us_ape = simulate_closed_loop(dyn, feature_fn, A_ape, B_ape, K_ape, x0, params.u_max, dt, 100)
+    xs_gpe, us_gpe = simulate_closed_loop(dyn, feature_fn, A_gpe, B_gpe, K_gpe, x0, params.u_max, dt, 100)
+    rmse_ape = np.sqrt(np.mean(xs_ape**2))
+    rmse_gpe = np.sqrt(np.mean(xs_gpe**2))
+    energy_ape = np.sum(us_ape**2)
+    energy_gpe = np.sum(us_gpe**2)
+    print(f"\n{system_name.upper()} Koopman-LQR")
+    print(f"RMSE A-PE: {rmse_ape:.3f}, G-PE: {rmse_gpe:.3f}")
+    print(f"Energy A-PE: {energy_ape:.3f}, G-PE: {energy_gpe:.3f}")
+
+
+if __name__ == '__main__':
+    for sys in ['duffing', 'lorenz', 'vdp']:
+        lqr_for_system(sys)

--- a/gpe_tracking_control.py
+++ b/gpe_tracking_control.py
@@ -1,0 +1,311 @@
+import numpy as np
+from typing import Callable, Tuple, Dict
+
+from gpe_three_systems_experiment import (
+    DuffingParams,
+    LorenzParams,
+    VanDerPolParams,
+    duffing_dynamics,
+    lorenz_dynamics,
+    vdp_dynamics,
+    rk4_step,
+    collect_data_a_pe,
+    collect_data_g_pe,
+    build_phi_matrix,
+    edmdc_fit,
+    lambda_min_cov,
+    poly_features_2d,
+    poly_features_3d,
+)
+import gpe_visualization as viz
+
+
+# -----------------------------------------------------------------------------
+# Prediction matrices and MPC-like controller
+# -----------------------------------------------------------------------------
+
+def _prediction_matrices(A_phi: np.ndarray, B_phi: np.ndarray, C: np.ndarray, horizon: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Pre-compute lifted-space prediction matrices for a finite horizon."""
+    n_phi = A_phi.shape[0]
+    dims = C.shape[0]
+    F = np.zeros((dims * horizon, n_phi))
+    G = np.zeros((dims * horizon, horizon))
+    A_power = np.eye(n_phi)
+    for i in range(horizon):
+        A_power = A_power @ A_phi
+        F[dims * i : dims * (i + 1), :] = C @ A_power
+        for j in range(i + 1):
+            A_power_j = np.linalg.matrix_power(A_phi, i - j)
+            G[dims * i : dims * (i + 1), j] = (C @ A_power_j @ B_phi).flatten()
+    return F, G
+
+
+def run_tracking_controller(
+    dyn: Callable[[np.ndarray, float], np.ndarray],
+    A_phi: np.ndarray,
+    B_phi: np.ndarray,
+    feature_fn: Callable[[np.ndarray], np.ndarray],
+    dims: int,
+    dt: float,
+    ref_traj: np.ndarray,
+    noise_seq: np.ndarray,
+    horizon: int = 10,
+    reg_u: float = 1e-3,
+    disturb_step: int = None,
+    disturb: np.ndarray = None,
+    return_traj: bool = False,
+    x0: np.ndarray = None,
+) -> Dict[str, float]:
+    """Run a simple MPC-like controller on the Koopman model."""
+    n_steps = ref_traj.shape[0] - 1
+    n_phi = A_phi.shape[0]
+    C = np.zeros((dims, n_phi))
+    C[:, :dims] = np.eye(dims)
+    F, G = _prediction_matrices(A_phi, B_phi, C, horizon)
+
+    if x0 is None:
+        x = ref_traj[0].copy()
+    else:
+        x = x0.copy()
+    X_hist = [x.copy()]
+    U_hist = []
+    for k in range(n_steps):
+        phi0 = feature_fn(x)
+        r_seg = ref_traj[k + 1 : k + horizon + 1]
+        if r_seg.shape[0] < horizon:
+            pad = np.repeat(r_seg[-1:, :], horizon - r_seg.shape[0], axis=0)
+            r_seg = np.vstack([r_seg, pad])
+        r_stack = r_seg.reshape(-1)
+        x_pred0 = F @ phi0
+        H = G.T @ G + reg_u * np.eye(horizon)
+        b = G.T @ (r_stack - x_pred0)
+        U_seq = np.linalg.solve(H, b)
+        u = float(U_seq[0])
+        x = rk4_step(x, u, dt, dyn)
+        x += noise_seq[k]
+        if disturb_step is not None and k == disturb_step:
+            x += disturb
+        X_hist.append(x.copy())
+        U_hist.append(u)
+
+    X_hist = np.array(X_hist)
+    ref_used = ref_traj[: X_hist.shape[0]]
+    err = X_hist - ref_used
+    rmse = float(np.sqrt(np.mean(err**2)))
+    energy = float(np.sum(np.array(U_hist) ** 2))
+    if disturb_step is not None:
+        err_post = err[disturb_step + 1 :]
+        robust_rmse = float(np.sqrt(np.mean(err_post**2)))
+    else:
+        robust_rmse = rmse
+    out = {"rmse": rmse, "energy": energy, "robust": robust_rmse}
+    if return_traj:
+        out["traj"] = X_hist
+    return out
+
+
+def run_pic_controller(
+    dyn: Callable[[np.ndarray, float], np.ndarray],
+    A_phi: np.ndarray,
+    B_phi: np.ndarray,
+    feature_fn: Callable[[np.ndarray], np.ndarray],
+    dims: int,
+    dt: float,
+    ref_traj: np.ndarray,
+    noise_seq: np.ndarray,
+    horizon: int = 15,
+    n_samples: int = 200,
+    lamb: float = 1.0,
+    u_max: float = 3.0,
+    disturb_step: int = None,
+    disturb: np.ndarray = None,
+    return_traj: bool = False,
+    x0: np.ndarray = None,
+    sigma: float = 0.5,
+) -> Dict[str, float]:
+    """Run a path-integral MPC controller on the Koopman model."""
+    n_steps = ref_traj.shape[0] - 1
+    x = ref_traj[0].copy() if x0 is None else x0.copy()
+    X_hist = [x.copy()]
+    U_hist = []
+    nominal = np.zeros(horizon)
+    for k in range(n_steps):
+        phi0 = feature_fn(x)
+        noise = sigma * np.random.randn(n_samples, horizon)
+        U_samples = np.clip(nominal + noise, -u_max, u_max)
+        costs = np.zeros(n_samples)
+        for i in range(n_samples):
+            phi = phi0.copy()
+            cost = 0.0
+            for j in range(horizon):
+                u = U_samples[i, j]
+                phi = A_phi @ phi + (B_phi.flatten() * u)
+                x_pred = phi[:dims]
+                r = ref_traj[min(k + j + 1, ref_traj.shape[0] - 1)]
+                cost += np.sum((x_pred - r) ** 2) + 0.01 * u**2
+            costs[i] = cost
+        w = np.exp(-costs / lamb)
+        w /= np.sum(w) + 1e-12
+        nominal = w @ U_samples
+        u = float(nominal[0])
+        nominal = np.append(nominal[1:], nominal[-1])
+        x = rk4_step(x, u, dt, dyn)
+        x += noise_seq[k]
+        if disturb_step is not None and k == disturb_step:
+            x += disturb
+        X_hist.append(x.copy())
+        U_hist.append(u)
+    X_hist = np.array(X_hist)
+    ref_used = ref_traj[: X_hist.shape[0]]
+    err = X_hist - ref_used
+    rmse = float(np.sqrt(np.mean(err**2)))
+    energy = float(np.sum(np.array(U_hist) ** 2))
+    if disturb_step is not None:
+        err_post = err[disturb_step + 1 :]
+        robust_rmse = float(np.sqrt(np.mean(err_post**2)))
+    else:
+        robust_rmse = rmse
+    out = {"rmse": rmse, "energy": energy, "robust": robust_rmse}
+    if return_traj:
+        out["traj"] = X_hist
+    return out
+
+
+# -----------------------------------------------------------------------------
+# Tracking experiment
+# -----------------------------------------------------------------------------
+
+def run_tracking_experiment(
+    system_name: str,
+    dt: float = 0.01,
+    L_seg: int = 20,
+    N_max: int = 200,
+    gamma: float = 1e-2,
+    rho0: float = 6.0,
+    cov_window: int = 2000,
+    ratio_window: int = 2000,
+) -> None:
+    """Collect data, identify models, and run tracking control for a system."""
+    if system_name == "duffing":
+        params = DuffingParams()
+        dyn = lambda x, u: duffing_dynamics(x, u, params)
+        feature_fn = lambda x: poly_features_2d(x, degree=3)
+        dims = 2
+        grid_sizes = (12, 24, 36)
+    elif system_name == "lorenz":
+        params = LorenzParams()
+        dyn = lambda x, u: lorenz_dynamics(x, u, params)
+        feature_fn = lambda x: poly_features_3d(x, degree=2)
+        dims = 3
+        grid_sizes = (8, 12, 16)
+    elif system_name == "vdp":
+        params = VanDerPolParams()
+        dyn = lambda x, u: vdp_dynamics(x, u, params)
+        feature_fn = lambda x: poly_features_2d(x, degree=3)
+        dims = 2
+        grid_sizes = (12, 24, 36)
+    else:
+        raise ValueError(f"Unknown system: {system_name}")
+
+    # A-PE data
+    X_ape, U_ape = collect_data_a_pe(dyn, params, dt, L_seg, N_max, dims)
+    Phi_ape = build_phi_matrix(X_ape[:-1], feature_fn)
+    Phi_next_ape = build_phi_matrix(X_ape[1:], feature_fn)
+    U_row_ape = U_ape.reshape(1, -1)
+    A_phi_ape, B_phi_ape = edmdc_fit(Phi_ape, Phi_next_ape, U_row_ape)
+
+    # G-PE data
+    X_gpe, U_gpe, log_gpe = collect_data_g_pe(
+        dyn=dyn,
+        p=params,
+        dt=dt,
+        L_seg=L_seg,
+        max_segments=N_max,
+        state_dim=dims,
+        feature_fn=feature_fn,
+        dims=dims,
+        grid_sizes=grid_sizes,
+        gamma=gamma,
+        rho0=rho0,
+        cov_window=cov_window,
+        ratio_window=ratio_window,
+    )
+    Phi_gpe = build_phi_matrix(X_gpe[:-1], feature_fn)
+    Phi_next_gpe = build_phi_matrix(X_gpe[1:], feature_fn)
+    U_row_gpe = U_gpe.reshape(1, -1)
+    A_phi_gpe, B_phi_gpe = edmdc_fit(Phi_gpe, Phi_next_gpe, U_row_gpe)
+
+    # Metrics
+    lam_x_ape = lambda_min_cov(X_ape)
+    lam_x_gpe = lambda_min_cov(X_gpe)
+    Phi_c_ape = Phi_ape - Phi_ape.mean(axis=1, keepdims=True)
+    Sigma_phi_ape = (Phi_c_ape @ Phi_c_ape.T) / Phi_c_ape.shape[1]
+    lam_phi_ape = float(np.linalg.eigvalsh(Sigma_phi_ape).min())
+    Phi_c_gpe = Phi_gpe - Phi_gpe.mean(axis=1, keepdims=True)
+    Sigma_phi_gpe = (Phi_c_gpe @ Phi_c_gpe.T) / Phi_c_gpe.shape[1]
+    lam_phi_gpe = float(np.linalg.eigvalsh(Sigma_phi_gpe).min())
+
+    # Tracking controller: drive from random x0 to origin
+    n_steps_ctrl = 100
+    ref_traj = np.zeros((n_steps_ctrl + 1, dims))
+    x0 = np.random.randn(dims)
+    noise_seq = 0.01 * np.random.randn(n_steps_ctrl, dims)
+    disturb_step = n_steps_ctrl // 2
+    disturb = 0.1 * np.random.randn(dims)
+    metrics_ape = run_pic_controller(
+        dyn,
+        A_phi_ape,
+        B_phi_ape,
+        feature_fn,
+        dims,
+        dt,
+        ref_traj,
+        noise_seq,
+        horizon=15,
+        n_samples=200,
+        u_max=params.u_max,
+        disturb_step=disturb_step,
+        disturb=disturb,
+        return_traj=True,
+        x0=x0,
+    )
+    metrics_gpe = run_pic_controller(
+        dyn,
+        A_phi_gpe,
+        B_phi_gpe,
+        feature_fn,
+        dims,
+        dt,
+        ref_traj,
+        noise_seq,
+        horizon=15,
+        n_samples=200,
+        u_max=params.u_max,
+        disturb_step=disturb_step,
+        disturb=disturb,
+        return_traj=True,
+        x0=x0,
+    )
+
+    print(f"\n===== {system_name.upper()} SYSTEM =====")
+    print("A-PE segments (random):", len(U_ape))
+    print("G-PE segments:", len(U_gpe))
+    print(f"λ_min(Σ_x) A-PE: {lam_x_ape:.3e}, G-PE: {lam_x_gpe:.3e}")
+    print(f"λ_min(Σ_φ) A-PE: {lam_phi_ape:.3e}, G-PE: {lam_phi_gpe:.3e}")
+    print("Tracking RMSE A-PE: {0:.3e}, G-PE: {1:.3e}".format(metrics_ape["rmse"], metrics_gpe["rmse"]))
+    print("Control energy A-PE: {0:.3e}, G-PE: {1:.3e}".format(metrics_ape["energy"], metrics_gpe["energy"]))
+    print(
+        "Post-disturb RMSE A-PE: {0:.3e}, G-PE: {1:.3e}".format(
+            metrics_ape["robust"], metrics_gpe["robust"]
+        )
+    )
+
+    viz.plot_phase_portraits(system_name, X_ape, X_gpe)
+    viz.plot_lambda_history(system_name, log_gpe["lam"], gamma)
+    viz.plot_ratio_history(system_name, log_gpe["ratios"], rho0)
+    viz.plot_tracking(system_name, ref_traj, metrics_ape["traj"], metrics_gpe["traj"], dt)
+
+
+if __name__ == "__main__":
+    for sys in ["duffing", "lorenz", "vdp"]:
+        run_tracking_experiment(system_name=sys)

--- a/gpe_visualization.py
+++ b/gpe_visualization.py
@@ -1,0 +1,99 @@
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+
+
+def _ensure_dir(path="figures"):
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def plot_phase_portraits(system_name, X_ape, X_gpe, save_dir="figures"):
+    """Plot phase portraits for A-PE and G-PE datasets."""
+    save_dir = _ensure_dir(save_dir)
+    dims = X_ape.shape[1]
+    if dims == 2:
+        plt.figure(figsize=(5, 4))
+        plt.plot(X_ape[:, 0], X_ape[:, 1], ".", ms=1.0, alpha=0.5, label="A-PE")
+        plt.plot(X_gpe[:, 0], X_gpe[:, 1], ".", ms=1.0, alpha=0.5, label="G-PE")
+        plt.xlabel("$x_1$")
+        plt.ylabel("$x_2$")
+        plt.title(f"{system_name} phase portrait")
+        plt.legend()
+        plt.grid(True)
+        plt.axis("equal")
+    elif dims == 3:
+        fig = plt.figure(figsize=(6, 5))
+        ax = fig.add_subplot(111, projection="3d")
+        ax.scatter(X_ape[:, 0], X_ape[:, 1], X_ape[:, 2], s=2, alpha=0.4, label="A-PE")
+        ax.scatter(X_gpe[:, 0], X_gpe[:, 1], X_gpe[:, 2], s=2, alpha=0.4, label="G-PE")
+        ax.set_xlabel("$x_1$")
+        ax.set_ylabel("$x_2$")
+        ax.set_zlabel("$x_3$")
+        ax.set_title(f"{system_name} phase portrait")
+        ax.legend()
+    else:
+        raise ValueError("Unsupported dimension for phase portrait")
+    plt.tight_layout()
+    plt.savefig(os.path.join(save_dir, f"{system_name}_phase_portrait.png"), dpi=160)
+    plt.close()
+
+
+def plot_lambda_history(system_name, lam_hist, gamma, save_dir="figures"):
+    """Plot lambda_min evolution for G-PE."""
+    save_dir = _ensure_dir(save_dir)
+    seg = np.arange(1, len(lam_hist) + 1)
+    plt.figure(figsize=(6, 4))
+    plt.plot(seg, np.array(lam_hist) + 1e-12, "o-")
+    plt.axhline(gamma, color="k", ls="--", label=r"$\gamma$")
+    plt.yscale("log")
+    plt.xlabel("Greedy segments")
+    plt.ylabel(r"$\lambda_{\min}(\Sigma_x)$")
+    plt.title(f"{system_name} lambda history")
+    plt.grid(True, which="both")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(os.path.join(save_dir, f"{system_name}_lambda_history.png"), dpi=160)
+    plt.close()
+
+
+def plot_ratio_history(system_name, ratio_hist, rho0, save_dir="figures"):
+    """Plot multi-scale non-clustering ratios."""
+    save_dir = _ensure_dir(save_dir)
+    ratio_arr = np.array(ratio_hist)
+    seg = np.arange(1, ratio_arr.shape[0] + 1)
+    plt.figure(figsize=(6, 4))
+    for i in range(ratio_arr.shape[1]):
+        plt.plot(seg, ratio_arr[:, i], "o-", label=f"grid {i}")
+    plt.axhline(rho0, color="k", ls="--", label=r"$\rho_0$")
+    plt.yscale("log")
+    plt.xlabel("Greedy segments")
+    plt.ylabel("max-count / expected")
+    plt.title(f"{system_name} non-clustering ratios")
+    plt.grid(True, which="both")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(os.path.join(save_dir, f"{system_name}_ratio_history.png"), dpi=160)
+    plt.close()
+
+
+def plot_tracking(system_name, ref_traj, traj_ape, traj_gpe, dt, save_dir="figures"):
+    """Plot reference tracking for A-PE and G-PE models."""
+    save_dir = _ensure_dir(save_dir)
+    t = np.arange(ref_traj.shape[0]) * dt
+    dims = ref_traj.shape[1]
+    plt.figure(figsize=(8, 3 * dims))
+    for d in range(dims):
+        ax = plt.subplot(dims, 1, d + 1)
+        ax.plot(t, ref_traj[:, d], "k--", lw=1.5, label="ref")
+        ax.plot(t, traj_ape[:, d], label="A-PE")
+        ax.plot(t, traj_gpe[:, d], label="G-PE")
+        ax.set_xlabel("Time (s)")
+        ax.set_ylabel(f"$x_{d+1}$")
+        ax.grid(True)
+        if d == 0:
+            ax.legend()
+    plt.tight_layout()
+    plt.savefig(os.path.join(save_dir, f"{system_name}_tracking.png"), dpi=160)
+    plt.close()


### PR DESCRIPTION
## Summary
- add Koopman-LQR controller that stabilizes Duffing, Lorenz, and VDP models learned from A-PE and G-PE data

## Testing
- `python3 gpe_lqr_control.py`


------
https://chatgpt.com/codex/tasks/task_e_68b32898e3408325bb2a101d2204ca65